### PR TITLE
chore: promote spring-test to version 0.0.2

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/spring-test
-  version: 0.0.1
+  version: 0.0.2
   name: spring-test
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote spring-test to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
